### PR TITLE
Honor extra_model_paths.yaml when choosing download destination

### DIFF
--- a/server.py
+++ b/server.py
@@ -1155,6 +1155,43 @@ def lookup_civitai_by_hash(file_hash):
         return None
 
 
+def resolve_download_dir(target_dir):
+    """Resolve the directory to download a model into, honoring extra_model_paths.yaml.
+
+    Uses ComfyUI's registered folder paths (get_folder_paths) - which include any
+    locations added by extra_model_paths.yaml - instead of hardcoding the base
+    ComfyUI models dir. The first registered path is ComfyUI's default target;
+    set `is_default: true` for a location in extra_model_paths.yaml to make it the
+    default download destination.
+    """
+    norm = target_dir.replace('\\', '/').strip('/')
+    parts = [p for p in norm.split('/') if p]
+    if not parts:
+        return folder_paths.models_dir
+
+    category, sub = parts[0], parts[1:]
+    try:
+        all_paths = folder_paths.get_folder_paths(category)
+    except Exception:
+        all_paths = []
+
+    base = None
+    if all_paths:
+        # Prefer a registered path whose final segment matches the requested
+        # category (e.g. ".../models/diffusion_models" over ".../models/unet"),
+        # otherwise use the first (default) registered path.
+        for p in all_paths:
+            if os.path.basename(os.path.normpath(p)).lower() == category.lower():
+                base = p
+                break
+        if base is None:
+            base = all_paths[0]
+    if base is None:
+        base = os.path.join(folder_paths.models_dir, category)
+
+    return os.path.join(base, *sub) if sub else base
+
+
 def find_model_file_path(target_dir, filename):
     """Find the full path to a model file, checking all configured model paths including extra_model_paths.yaml"""
 
@@ -2975,9 +3012,8 @@ def _download_model_thread(download_id, hf_repo, hf_path, filename, target_dir):
     try:
         from huggingface_hub import hf_hub_download
 
-        # Normalize path separators for the OS
-        target_dir_normalized = target_dir.replace('/', os.sep).replace('\\', os.sep)
-        target_path = os.path.join(folder_paths.models_dir, target_dir_normalized)
+        # Resolve target dir via ComfyUI's folder paths (honors extra_model_paths.yaml)
+        target_path = resolve_download_dir(target_dir)
 
         # Create directory if it doesn't exist
         try:
@@ -3130,9 +3166,8 @@ def _download_model_thread(download_id, hf_repo, hf_path, filename, target_dir):
 def _download_from_url_thread(download_id, url, filename, target_dir):
     """Background thread to download a model from direct URL"""
     try:
-        # Normalize path separators for the OS
-        target_dir_normalized = target_dir.replace('/', os.sep).replace('\\', os.sep)
-        target_path = os.path.join(folder_paths.models_dir, target_dir_normalized)
+        # Resolve target dir via ComfyUI's folder paths (honors extra_model_paths.yaml)
+        target_path = resolve_download_dir(target_dir)
 
         # Create directory if it doesn't exist
         try:
@@ -5122,9 +5157,8 @@ async def queue_download_endpoint(request):
             if hf_token:
                 headers['Authorization'] = f'Bearer {hf_token}'
 
-        # Normalize path
-        target_dir_normalized = target_dir.replace('/', os.sep).replace('\\', os.sep)
-        dest_path = os.path.join(folder_paths.models_dir, target_dir_normalized, filename)
+        # Resolve target dir via ComfyUI's folder paths (honors extra_model_paths.yaml)
+        dest_path = os.path.join(resolve_download_dir(target_dir), filename)
 
         # Create directory
         os.makedirs(os.path.dirname(dest_path), exist_ok=True)


### PR DESCRIPTION
## Problem

Downloads are always written under the base ComfyUI models dir (`folder_paths.models_dir`), ignoring any locations registered via `extra_model_paths.yaml`. Users who keep their models on another drive (e.g. `base_path: E:/ComfyUI` with `is_default: true`) see downloaded files land in the default install location instead of their configured path.

This is inconsistent with the rest of the extension: `find_model_file_path()` already resolves paths through `folder_paths.get_folder_paths()` (which includes `extra_model_paths.yaml` entries) for its existence checks — only the **download** path hardcodes `folder_paths.models_dir`.

## Fix

Add `resolve_download_dir()`, which resolves the target directory via ComfyUI's registered folder paths instead of the hardcoded base dir, and wire it into the three download paths:

- `_download_model_thread`
- `_download_from_url_thread`
- the queue download endpoint

It prefers the registered path whose final segment matches the requested category (e.g. `.../models/diffusion_models` over `.../models/unet`) and otherwise falls back to the first (default) registered path. So setting `is_default: true` for a location in `extra_model_paths.yaml` makes that location the download destination, matching ComfyUI's own documented behavior ("used as the default dirs for eg downloads").

Falls back gracefully to the previous behavior (`folder_paths.models_dir`) for any category ComfyUI doesn't know about.

## Testing

Verified against a live ComfyUI `folder_paths` with an `extra_model_paths.yaml` pointing `base_path` to a second drive with `is_default: true`. All categories resolve to the configured location, e.g.:

```
diffusion_models -> E:\ComfyUI\models\diffusion_models   (correctly picks diffusion_models over unet)
vae              -> E:\ComfyUI\models\vae
loras            -> E:\ComfyUI\models\loras
checkpoints      -> E:\ComfyUI\models\checkpoints
```

`python -m py_compile server.py` passes.