### PR TITLE
Dedupe models by basename and infer directory from loader node class

### DIFF
--- a/server.py
+++ b/server.py
@@ -1062,6 +1062,32 @@ URL_DIRECTORY_HINTS = {
     '/pulid/': 'pulid',
 }
 
+# Loader node class -> destination directory.
+# A node's class is a far stronger signal than its filename: a UNETLoader always
+# loads from diffusion_models, a VAELoader from vae, etc. This is used as a high
+# priority directory source so models with no filename pattern (e.g. Z-Image)
+# are placed correctly instead of falling through to the 'checkpoints' default.
+LOADER_NODE_DIRECTORY = {
+    'UNETLoader': 'diffusion_models',
+    'CheckpointLoaderSimple': 'checkpoints',
+    'CheckpointLoader': 'checkpoints',
+    'unCLIPCheckpointLoader': 'checkpoints',
+    'ImageOnlyCheckpointLoader': 'checkpoints',
+    'VAELoader': 'vae',
+    'CLIPLoader': 'text_encoders',
+    'DualCLIPLoader': 'text_encoders',
+    'TripleCLIPLoader': 'text_encoders',
+    'QuadrupleCLIPLoader': 'text_encoders',
+    'CLIPVisionLoader': 'clip_vision',
+    'ControlNetLoader': 'controlnet',
+    'DiffControlNetLoader': 'controlnet',
+    'LoraLoader': 'loras',
+    'LoraLoaderModelOnly': 'loras',
+    'StyleModelLoader': 'style_models',
+    'GLIGENLoader': 'gligen',
+    'UpscaleModelLoader': 'upscale_models',
+}
+
 
 def identify_model_type_from_filename(model_name):
     """Identify model type from filename patterns"""
@@ -1519,6 +1545,16 @@ def scan_workflow_for_models(workflow_json):
             model_files.add(model_name)
             model_name_map[model_name] = model_name
 
+    # Basenames already referenced by real loader nodes (properties/widgets).
+    # The regex pass below also scans markdown notes, which commonly repeat the
+    # same file by its bare name (no subfolder). Without this guard a note's
+    # "model.safetensors" and a loader's "subdir/model.safetensors" are treated
+    # as two different models and downloaded twice. Dedupe by basename so the
+    # authoritative loader reference (which carries the correct subfolder) wins.
+    known_basenames = {
+        os.path.basename(name.replace('\\', '/')) for name in node_models
+    }
+
     for model in model_files_raw:
         cleaned = model.strip()
         if cleaned and cleaned[0].isalnum():
@@ -1529,6 +1565,10 @@ def scan_workflow_for_models(workflow_json):
                     decoded = urllib.parse.unquote(cleaned)
                 except Exception:
                     decoded = cleaned
+
+                # Skip note/text references already covered by a loader node
+                if os.path.basename(decoded.replace('\\', '/')) in known_basenames:
+                    continue
 
                 model_files.add(decoded)
                 model_name_map[decoded] = cleaned  # Keep original for URL matching
@@ -1554,6 +1594,10 @@ def scan_workflow_for_models(workflow_json):
 
         original_name = model_name_map.get(model, model)
 
+        # Basename (a loader value may carry a subfolder, e.g. "z-image\\x.safetensors"),
+        # while the download URL only ever contains the bare filename.
+        model_basename = os.path.basename(model.replace('\\', '/'))
+
         for url in cleaned_urls:
             # Check decoded name in URL
             if model in url:
@@ -1561,6 +1605,13 @@ def scan_workflow_for_models(workflow_json):
                 break
             # Check original (possibly URL-encoded) name in URL
             if original_name in url:
+                model_url_map[model] = url
+                break
+            # Check bare basename (handles subfoldered loader values)
+            if model_basename != model and (
+                model_basename in url
+                or urllib.parse.quote(model_basename, safe='') in url
+            ):
                 model_url_map[model] = url
                 break
             # Check URL-encoded version of decoded name
@@ -1592,7 +1643,14 @@ def scan_workflow_for_models(workflow_json):
         if from_node_properties and node_models[model].get('directory'):
             target_dir = node_models[model]['directory']
 
-        # Second priority: Check URL for directory hints
+        # Second priority: infer the directory from the loader node's class.
+        # More reliable than guessing from the filename, and fixes models with
+        # no filename pattern (e.g. Z-Image) that would otherwise default to
+        # 'checkpoints'.
+        elif from_node_properties and node_models[model].get('node_type') in LOADER_NODE_DIRECTORY:
+            target_dir = LOADER_NODE_DIRECTORY[node_models[model]['node_type']]
+
+        # Third priority: Check URL for directory hints
         elif url:
             url_lower = url.lower()
             for url_path, directory in URL_DIRECTORY_HINTS.items():

--- a/server.py
+++ b/server.py
@@ -1155,6 +1155,43 @@ def lookup_civitai_by_hash(file_hash):
         return None
 
 
+def resolve_download_dir(target_dir):
+    """Resolve the directory to download a model into, honoring extra_model_paths.yaml.
+
+    Uses ComfyUI's registered folder paths (get_folder_paths) - which include any
+    locations added by extra_model_paths.yaml - instead of hardcoding the base
+    ComfyUI models dir. The first registered path is ComfyUI's default target;
+    set `is_default: true` for a location in extra_model_paths.yaml to make it the
+    default download destination.
+    """
+    norm = target_dir.replace('\\', '/').strip('/')
+    parts = [p for p in norm.split('/') if p]
+    if not parts:
+        return folder_paths.models_dir
+
+    category, sub = parts[0], parts[1:]
+    try:
+        all_paths = folder_paths.get_folder_paths(category)
+    except Exception:
+        all_paths = []
+
+    base = None
+    if all_paths:
+        # Prefer a registered path whose final segment matches the requested
+        # category (e.g. ".../models/diffusion_models" over ".../models/unet"),
+        # otherwise use the first (default) registered path.
+        for p in all_paths:
+            if os.path.basename(os.path.normpath(p)).lower() == category.lower():
+                base = p
+                break
+        if base is None:
+            base = all_paths[0]
+    if base is None:
+        base = os.path.join(folder_paths.models_dir, category)
+
+    return os.path.join(base, *sub) if sub else base
+
+
 def find_model_file_path(target_dir, filename):
     """Find the full path to a model file, checking all configured model paths including extra_model_paths.yaml"""
 
@@ -2975,9 +3012,8 @@ def _download_model_thread(download_id, hf_repo, hf_path, filename, target_dir):
     try:
         from huggingface_hub import hf_hub_download
 
-        # Normalize path separators for the OS
-        target_dir_normalized = target_dir.replace('/', os.sep).replace('\\', os.sep)
-        target_path = os.path.join(folder_paths.models_dir, target_dir_normalized)
+        # Resolve target dir via ComfyUI's folder paths (honors extra_model_paths.yaml)
+        target_path = resolve_download_dir(target_dir)
 
         # Create directory if it doesn't exist
         try:
@@ -3130,9 +3166,8 @@ def _download_model_thread(download_id, hf_repo, hf_path, filename, target_dir):
 def _download_from_url_thread(download_id, url, filename, target_dir):
     """Background thread to download a model from direct URL"""
     try:
-        # Normalize path separators for the OS
-        target_dir_normalized = target_dir.replace('/', os.sep).replace('\\', os.sep)
-        target_path = os.path.join(folder_paths.models_dir, target_dir_normalized)
+        # Resolve target dir via ComfyUI's folder paths (honors extra_model_paths.yaml)
+        target_path = resolve_download_dir(target_dir)
 
         # Create directory if it doesn't exist
         try:
@@ -5122,9 +5157,8 @@ async def queue_download_endpoint(request):
             if hf_token:
                 headers['Authorization'] = f'Bearer {hf_token}'
 
-        # Normalize path
-        target_dir_normalized = target_dir.replace('/', os.sep).replace('\\', os.sep)
-        dest_path = os.path.join(folder_paths.models_dir, target_dir_normalized, filename)
+        # Resolve target dir via ComfyUI's folder paths (honors extra_model_paths.yaml)
+        dest_path = os.path.join(resolve_download_dir(target_dir), filename)
 
         # Create directory
         os.makedirs(os.path.dirname(dest_path), exist_ok=True)


### PR DESCRIPTION
Two related fixes to workflow model scanning in `scan_workflow_for_models`.

### 1. Duplicate downloads from models referenced in notes
A model loaded by a loader node can carry a subfolder in its widget value (e.g. `z-image\model.safetensors`). The same file is often also advertised by a download button embedded in a markdown/info note, where it appears by its **bare** filename (`model.safetensors`). The regex pass over the whole workflow JSON picked up the bare name, and because the two strings differ, the file was listed — and downloaded — **twice**, into two different folders.

Fix: dedupe the regex/note pass by basename against names already found in loader nodes (properties + widgets). The authoritative loader reference, which carries the correct subfolder, wins.

### 2. Wrong destination for models with no filename pattern
Models matching no `FILENAME_TYPE_PATTERNS` entry (e.g. Z-Image) fell through to the `checkpoints` default, even when loaded by a `UNETLoader` (which reads from `diffusion_models`).

Fix: add `LOADER_NODE_DIRECTORY` and infer the destination from the loader node's class (`UNETLoader → diffusion_models`, `VAELoader → vae`, `CLIPLoader → text_encoders`, …) as a high-priority directory source, above the URL hint and the filename fallback.

### 3. URL matching by basename
So a subfoldered loader value still resolves to the URL advertised in a note (which only ever uses the bare filename).

### Testing
Verified with a standalone harness calling `scan_workflow_for_models` on a synthetic workflow mirroring the Z-Image case (UNETLoader with `z-image\…` + a note containing the bare filename and HF URL):
- exactly **1** entry for the model (dedupe)
- directory resolved to `diffusion_models` (loader-class mapping)
- subfolder preserved in the filename
- download URL resolved from the note **with local caches removed** (clean-install behavior)
- a `VAELoader` entry correctly resolved to `vae`